### PR TITLE
Use `strip = "symbols"`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = ["crates/*"]
 
 [profile.release]
 codegen-units = 1
+strip = "symbols"
 debug = false
 lto = true
 opt-level = "z"


### PR DESCRIPTION
https://www.reddit.com/r/rust/comments/gu1b1d/adding_symbol_stripping_to_cargo/

```
active toolchain
----------------

stable-x86_64-unknown-linux-gnu (overridden by '/home/foobar/gg/WasmRS/mp-tuning/rust-toolchain.toml')
rustc 1.64.0 (a55dd71d5 2022-09-19)
```

## Where it began - `1.64.0 stable`

ls -lh target/wasm32-*/release/*.wasm
-rwxrwxr-x 2 foobar foobar  219 Sep 27 02:19 target/wasm32-unknown-unknown/release/basic.wasm
-rwxrwxr-x 2 foobar foobar 172K Sep 27 02:19 target/wasm32-unknown-unknown/release/messagepack.wasm
-rwxrwxr-x 2 foobar foobar  318 Sep 27 02:19 target/wasm32-wasi/release/basic.wasm
-rwxrwxr-x 2 foobar foobar 249K Sep 27 02:19 target/wasm32-wasi/release/messagepack.wasm
ls -lh *.wasm
-rw-rw-r-- 1 foobar foobar 189 Sep 27 02:19 basic-wasi.wasm
-rw-rw-r-- 1 foobar foobar 176 Sep 27 02:19 basic.wasm
-rw-rw-r-- 1 foobar foobar 58K Sep 27 02:19 messagepack-wasi.wasm
-rw-rw-r-- 1 foobar foobar 35K Sep 27 02:19 messagepack.wasm

## strip = "symbols" - `1.64.0 stable`

wasm-opt --strip-debug -Oz target/wasm32-wasi/release/messagepack.wasm -o messagepack-wasi.wasm
ls -lh target/wasm32-*/release/*.wasm
-rwxrwxr-x 2 foobar foobar 105 Sep 27 02:21 target/wasm32-unknown-unknown/release/basic.wasm
-rwxrwxr-x 2 foobar foobar 39K Sep 27 02:21 target/wasm32-unknown-unknown/release/messagepack.wasm
-rwxrwxr-x 2 foobar foobar 145 Sep 27 02:21 target/wasm32-wasi/release/basic.wasm
-rwxrwxr-x 2 foobar foobar 67K Sep 27 02:21 target/wasm32-wasi/release/messagepack.wasm
ls -lh *.wasm
-rw-rw-r-- 1 foobar foobar  97 Sep 27 02:21 basic-wasi.wasm
-rw-rw-r-- 1 foobar foobar  97 Sep 27 02:21 basic.wasm
-rw-rw-r-- 1 foobar foobar 58K Sep 27 02:21 messagepack-wasi.wasm
-rw-rw-r-- 1 foobar foobar 34K Sep 27 02:21 messagepack.wasm
