### PR TITLE
Remove profile warning

### DIFF
--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.1.0"
 authors = []
 edition = "2021"
 
-[profile.release]
-
-
 [dependencies]
 wasmtime = "1.0.0"
 anyhow = { version = "1.0" }


### PR DESCRIPTION
Gets rid of annoyance

foobar@foobar-MS-7C77:~/gg/WasmRS/mp-tuning$ make
```
cargo build -p basic --release --target wasm32-unknown-unknown
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /home/foobar/gg/WasmRS/mp-tuning/crates/runner/Cargo.toml
```